### PR TITLE
17 improve soft deletes

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,7 +1,7 @@
 name: Fix PHP code style issues
 
 on:
-  push:
+  pull_request:
     paths:
       - '**.php'
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,7 +1,7 @@
 name: PHPStan
 
 on:
-  push:
+  pull_request:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,7 @@
 name: run-tests
 
 on:
-  push:
+  pull_request:
     paths:
       - '**.php'
       - '.github/workflows/run-tests.yml'

--- a/database/migrations/create_embeddings_table.php.stub
+++ b/database/migrations/create_embeddings_table.php.stub
@@ -21,6 +21,7 @@ return new class extends Migration
             $table->string('embedding_model');
             $table->uuid('content_hash');
             $table->vector('vector', {{ $dimensions }});
+            $table->boolean('__soft_deleted')->default(false);
             $table->timestamps();
 
             // Add indexes

--- a/src/Actions/CreateEmbedding.php
+++ b/src/Actions/CreateEmbedding.php
@@ -34,6 +34,7 @@ class CreateEmbedding
         $data = array_merge(
             $searchableData,
             $model->scoutMetadata(),
+            ['__soft_deleted' => method_exists($model, 'trashed') ? $model->trashed() : false]
         );
 
         $content = static::arrayToLabeledText($data);
@@ -122,7 +123,7 @@ class CreateEmbedding
 
         // Add __soft_deleted if Scout's soft delete is enabled
         if (config('scout.soft_delete', false) && method_exists($model, 'trashed')) {
-            $attributes['__soft_deleted'] = $model->trashed() ? 1 : 0;
+            $attributes['__soft_deleted'] = $model->trashed();
         }
 
         return (new Embedding)

--- a/src/Actions/CreateEmbedding.php
+++ b/src/Actions/CreateEmbedding.php
@@ -114,6 +114,17 @@ class CreateEmbedding
             'embedding_model' => $config->model,
         ]);
 
+        $attributes = [
+            'embedding_model' => $config->model,
+            'content_hash' => $contentHash,
+            'vector' => $vector,
+        ];
+
+        // Add __soft_deleted if Scout's soft delete is enabled
+        if (config('scout.soft_delete', false) && method_exists($model, 'trashed')) {
+            $attributes['__soft_deleted'] = $model->trashed() ? 1 : 0;
+        }
+
         return (new Embedding)
             ->forModel($model)
             ->updateOrCreate(
@@ -121,11 +132,7 @@ class CreateEmbedding
                     'embeddable_type' => get_class($model),
                     'embeddable_id' => $model->getKey(),
                 ],
-                [
-                    'embedding_model' => $config->model,
-                    'content_hash' => $contentHash,
-                    'vector' => $vector,
-                ]
+                $attributes
             );
     }
 }

--- a/src/Actions/SearchEmbedding.php
+++ b/src/Actions/SearchEmbedding.php
@@ -36,6 +36,7 @@ class SearchEmbedding
         $query->whereHasMorph('embeddable', [$model->getMorphClass()], function ($query) use ($builder, $model) {
             // When Scout soft delete is enabled, include soft-deleted models in the relationship check
             if (static::usesSoftDelete($model) && config('scout.soft_delete', false)) {
+                /** @phpstan-ignore-next-line */
                 $query->withTrashed();
             }
 

--- a/src/Actions/SearchEmbedding.php
+++ b/src/Actions/SearchEmbedding.php
@@ -28,10 +28,23 @@ class SearchEmbedding
             ->forModel($model)
             ->where('embeddable_type', $model->getMorphClass());
 
+        // Apply __soft_deleted property from the builder
+        if (isset($builder->wheres['__soft_deleted'])) {
+            $query->where('__soft_deleted', $builder->wheres['__soft_deleted']);
+        }
+
         $query->whereHasMorph('embeddable', [$model->getMorphClass()], function ($query) use ($builder, $model) {
+            // When Scout soft delete is enabled, include soft-deleted models in the relationship check
+            if (static::usesSoftDelete($model) && config('scout.soft_delete', false)) {
+                $query->withTrashed();
+            }
 
             if ($builder->wheres) {
                 foreach ($builder->wheres as $key => $value) {
+                    // Skip __soft_deleted as it's handled on the embeddings table
+                    if ($key === '__soft_deleted') {
+                        continue;
+                    }
                     $query->where($key, $value);
                 }
             }
@@ -46,10 +59,6 @@ class SearchEmbedding
                 foreach ($builder->whereNotIns as $field => $values) {
                     $query->whereNotIn($field, $values);
                 }
-            }
-
-            if (static::usesSoftDelete($model)) {
-                $query->whereNull('deleted_at');
             }
         });
 

--- a/src/Models/Embedding.php
+++ b/src/Models/Embedding.php
@@ -15,6 +15,7 @@ use Pgvector\Laravel\Vector;
  * @property string $embedding_model
  * @property string $content_hash
  * @property Vector $vector
+ * @property int $__soft_deleted
  * @property Carbon $created_at
  * @property Carbon $updated_at
  * */

--- a/src/Models/Embedding.php
+++ b/src/Models/Embedding.php
@@ -24,11 +24,18 @@ class Embedding extends Model
     use HasNeighbors;
 
     /**
-     * The attributes that aren't mass assignable.
+     * The attributes that are mass assignable.
      *
      * @var array<int, string>
      */
-    protected $guarded = [];
+    protected $fillable = [
+        'embeddable_id',
+        'embeddable_type',
+        'embedding_model',
+        'content_hash',
+        'vector',
+        '__soft_deleted',
+    ];
 
     /**
      * The attributes that should be cast.
@@ -37,6 +44,7 @@ class Embedding extends Model
      */
     protected $casts = [
         'vector' => Vector::class,
+        '__soft_deleted' => 'boolean',
     ];
 
     /**

--- a/tests/PgvectorEngineTest.php
+++ b/tests/PgvectorEngineTest.php
@@ -70,7 +70,7 @@ test('search method can filter by model properties', function () {
     expect($results->first()->embedding->neighbor_distance)->toBeFloat();
 
     $queries = DB::getQueryLog();
-    expect($queries)->toHaveCount(3);
+    expect($queries)->toHaveCount(2);
 });
 
 test('search method can order by model properties', function () {

--- a/tests/Support/Migrations/2024_11_06_000000_create_embeddings_table.php
+++ b/tests/Support/Migrations/2024_11_06_000000_create_embeddings_table.php
@@ -21,6 +21,7 @@ return new class extends Migration
             $table->string('embedding_model');
             $table->uuid('content_hash');
             $table->vector('vector', 3);
+            $table->boolean('__soft_deleted')->default(0);
             $table->timestamps();
 
             // Add indexes


### PR DESCRIPTION
This pull request adds the functionality documented here: https://laravel.com/docs/12.x/scout#soft-deleting

```php
use App\Models\Order;
 
// Include trashed records when retrieving results...
$orders = Order::search('Star Trek')->withTrashed()->get();
 
// Only include trashed records when retrieving results...
$orders = Order::search('Star Trek')->onlyTrashed()->get();
```
